### PR TITLE
fix: allow specifying nodePort via values.yaml

### DIFF
--- a/helm/nessie/templates/service.yaml
+++ b/helm/nessie/templates/service.yaml
@@ -37,6 +37,9 @@ spec:
       port: {{ .number }}
       targetPort: {{ .number }}
       protocol: TCP
+      {{- if and (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
     {{- end }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- if .Values.service.clusterIP }}


### PR DESCRIPTION
This PR adds support for specifying nodePort in service.ports via values.yaml.
Useful for local environments (e.g., kind, minikube) where fixed NodePort mapping is required.